### PR TITLE
Fix bug where nothing is sent unless "shell" is specified.

### DIFF
--- a/egressbuster.py
+++ b/egressbuster.py
@@ -68,6 +68,8 @@ def start_socket(ipaddr, base_port, shell):
     # 3 seconds is too short if commands are going to be entered
     if shell == "shell":
         timeout = 300
+    else:
+        timeout = 3
 
     # try block to catch exceptions
     try:


### PR DESCRIPTION
Turns out that by mentioning `timeout` on line 70, python forgets about the global variable, so when `timeout` is used on what is now line 76, it throws `UnboundLocalError: local variable 'timeout' referenced before assignment` which gets silently dropped, and the TCP connect never happens.